### PR TITLE
Fix: set a default baseHref if subFolder is set

### DIFF
--- a/builder/deploy/index.ts
+++ b/builder/deploy/index.ts
@@ -37,7 +37,7 @@ export default createBuilder<any>(
       const defaultBaseHref = builderConfig.subFolder
         ? (!builderConfig.subFolder.startsWith("/") ? "/" : "") 
             + builderConfig.subFolder 
-            + (!builderConfig.subFolder.endsWith("/") ? "/" : "");
+            + (!builderConfig.subFolder.endsWith("/") ? "/" : "")
         : "/";
       const overrides = {
         // if subFolder is set, should set baseHref accordingly

--- a/builder/deploy/index.ts
+++ b/builder/deploy/index.ts
@@ -34,9 +34,11 @@ export default createBuilder<any>(
     } else {
       const configuration = builderConfig.configuration ? builderConfig.configuration : "production";
 
-      const defaultBaseHref = (!builderConfig.subFolder.startsWith("/") ? "/" : "") 
-        + builderConfig.subFolder 
-        + (!builderConfig.subFolder.endsWith("/") ? "/" : "");
+      const defaultBaseHref = builderConfig.subFolder
+        ? (!builderConfig.subFolder.startsWith("/") ? "/" : "") 
+            + builderConfig.subFolder 
+            + (!builderConfig.subFolder.endsWith("/") ? "/" : "");
+        : "/";
       const overrides = {
         // if subFolder is set, should set baseHref accordingly
         ...(builderConfig.subFolder && { baseHref: defaultBaseHref}),

--- a/builder/deploy/index.ts
+++ b/builder/deploy/index.ts
@@ -34,7 +34,12 @@ export default createBuilder<any>(
     } else {
       const configuration = builderConfig.configuration ? builderConfig.configuration : "production";
 
+      const defaultBaseHref = (!builderConfig.subFolder.startsWith("/") ? "/" : "") 
+        + builderConfig.subFolder 
+        + (!builderConfig.subFolder.endsWith("/") ? "/" : "");
       const overrides = {
+        // if subFolder is set, should set baseHref accordingly
+        ...(builderConfig.subFolder && { baseHref: defaultBaseHref}),
         // this is an example how to override the workspace set of options
         ...(builderConfig.baseHref && { baseHref: builderConfig.baseHref })
       };


### PR DESCRIPTION
If subFolder is set up during initial configuration, it should set up baseHref accordingly (if not provided).

Otherwise the application won't load.

I am not sure If this is the best way to do it, happy if being corrected :)