### PR TITLE
fix: schema should not validate the accesskey and secret anymore

### DIFF
--- a/builder/ng-add/schema.json
+++ b/builder/ng-add/schema.json
@@ -106,9 +106,7 @@
   },
   "required": [
     "region",
-    "bucket",
-    "secretAccessKey",
-    "accessKeyId"
+    "bucket"
   ],
   "additionalProperties": false
 }


### PR DESCRIPTION
We won't have to validate the `secretAccesskey` & `accesskey` any more as we check this via environment variables.

Closes: #287 