### PR TITLE
Return error when any file upload fails

### DIFF
--- a/builder/deploy/index.ts
+++ b/builder/deploy/index.ts
@@ -91,9 +91,16 @@ export default createBuilder<any>(
       if (getAccessKeyId(deployConfig) || getSecretAccessKey(deployConfig)) {
         context.logger.info('Start uploading files...');
         const uploader = new Uploader(context, deployConfig);
-        await uploader.upload(files, filesPath);
-        context.logger.info('✔ Finished uploading files...');
-        return { success: true };
+        const success = await uploader.upload(files, filesPath);
+        if (success) {
+          context.logger.info('✔ Finished uploading files...');
+          return { success: true };
+        } else {
+          return {
+            error: `❌  Error during files upload`,
+            success: false,
+          };
+        }
       } else {
         return {
           error: `❌  Missing authentication settings for AWS`,

--- a/builder/deploy/uploader.ts
+++ b/builder/deploy/uploader.ts
@@ -33,13 +33,13 @@ export class Uploader {
     });
   }
 
-  async upload(files: string[], filesPath: string) {
+  async upload(files: string[], filesPath: string): boolean {
     try {
       if (!this._region || !this._bucket) {
         this._context.logger.error(
           `❌  Looks like you are missing some configuration`,
         );
-        return;
+        return false;
       }
 
       const params: HeadBucketRequest = {
@@ -56,11 +56,12 @@ export class Uploader {
           this._context.logger.error(
             `❌  The following error was found during the upload ${error}`,
           );
-          return;
+          throw error;
         });
     } catch {
-      return;
+      return false;
     }
+    return true;
   }
 
   uploadFiles(files: string[], filesPath: string) {
@@ -95,8 +96,9 @@ export class Uploader {
           `Uploaded file "${file.Key}" to ${file.Location}`,
         ),
       )
-      .catch((item) =>
-        this._context.logger.error(`Error uploading file: ${item}`),
-      );
+      .catch((item) => {
+        this._context.logger.error(`Error uploading file: ${item}`);
+        throw item;
+      });
   }
 }

--- a/builder/deploy/uploader.ts
+++ b/builder/deploy/uploader.ts
@@ -33,7 +33,7 @@ export class Uploader {
     });
   }
 
-  async upload(files: string[], filesPath: string): boolean {
+  async upload(files: string[], filesPath: string): Promise<boolean> {
     try {
       if (!this._region || !this._bucket) {
         this._context.logger.error(


### PR DESCRIPTION
For now `Uploader` only log errors and does not return any error or status.

`ng deploy` returns a success status even if no files are uploaded. It means CI jobs show success status even if upload fails.

Fix: method `Uploader().upload` returns a boolean status (true on success, false if any file upload failed)