### PR TITLE
fix: set bucket-owner-full-control on S3 upload with ALC policies

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,3 @@
+registry=https://npm.pkg.github.com/
+always-auth=true
+save-exact=true

--- a/builder/CHANGELOG.md
+++ b/builder/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [2.0.2](https://github.com/skoblenick/ngx-aws-deploy/compare/v2.0.1...v2.0.2) (2020-09-22)
+
+
+### Bug Fixes
+
+* set ALC policy for S3 upload ([3c5e6c3](https://github.com/skoblenick/ngx-aws-deploy/commit/3c5e6c388e0431b1610c2c6f18fe4958e42d7826))
+
 ## [2.0.1](https://github.com/Jefiozie/ngx-aws-deploy/compare/v2.0.0...v2.0.1) (2020-08-09)
 
 

--- a/builder/deploy/uploader.ts
+++ b/builder/deploy/uploader.ts
@@ -92,6 +92,7 @@ export class Uploader {
         : originFilePath,
       Body: body,
       ContentType: mimeTypes.lookup(fileName) || undefined,
+      ACL: 'bucket-owner-full-control'
     };
 
     await this._s3

--- a/builder/package-lock.json
+++ b/builder/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@jefiozie/ngx-aws-deploy",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/builder/package.json
+++ b/builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skoblenick/ngx-aws-deploy",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Deploy rou Angular app to Amazon S3 directly from the Angular CLI",
   "main": "index.js",
   "builders": "./builders.json",

--- a/builder/package.json
+++ b/builder/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@jefiozie/ngx-aws-deploy",
+  "name": "@skoblenick/ngx-aws-deploy",
   "version": "2.0.1",
   "description": "Deploy rou Angular app to Amazon S3 directly from the Angular CLI",
   "main": "index.js",
@@ -10,7 +10,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/Jefiozie/ngx-aws-deploy.git"
+    "url": "https://github.com/skoblenick/ngx-aws-deploy.git"
   },
   "scripts": {
     "build": "npm run copy && npm run build:schema && tsc",
@@ -81,7 +81,12 @@
       "@semantic-release/release-notes-generator",
       "@semantic-release/npm",
       "@semantic-release/changelog",
-      "@semantic-release/git"
+      [
+        "@semantic-release/git",
+        {
+          "message": "chore(release): ${nextRelease.version} [skip ci]"
+        }
+      ]
     ],
     "branches": [
       "master",


### PR DESCRIPTION
When there is an ACL policy set on the bucket you need to specify the ACL option on the `upload` method, see https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#upload-property. I have set the value to `bucket-owner-full-control` but this could easily be a configuration option in the builder settings or by environment variable if necessary. 

Otherwise the upload will fail, silently per #330 with:

```
✔ Build Completed
Start uploading files...
Error uploading file: AccessDenied: Access Denied
Error uploading file: AccessDenied: Access Denied
Error uploading file: AccessDenied: Access Denied
Error uploading file: AccessDenied: Access Denied
Error uploading file: AccessDenied: Access Denied
✔ Finished uploading files..
```