### PR TITLE
fix: remove the `production` configuration from `ng deploy` command

### DIFF
--- a/libs/ngx-aws-deploy/src/lib/deploy/config.ts
+++ b/libs/ngx-aws-deploy/src/lib/deploy/config.ts
@@ -1,10 +1,10 @@
 import { Schema } from './schema';
 
-export const getAccessKeyId = (builderConfig: Schema): string => {
+export const getAccessKeyId = (): string => {
   return process.env.NG_DEPLOY_AWS_ACCESS_KEY_ID as string;
 };
 
-export const getSecretAccessKey = (builderConfig: Schema): string => {
+export const getSecretAccessKey = (): string => {
   return process.env.NG_DEPLOY_AWS_SECRET_ACCESS_KEY as string;
 };
 

--- a/libs/ngx-aws-deploy/src/lib/deploy/uploader.ts
+++ b/libs/ngx-aws-deploy/src/lib/deploy/uploader.ts
@@ -28,8 +28,8 @@ export class Uploader {
     AWS.config.update({ region: this._region });
     this._s3 = new AWS.S3({
       apiVersion: 'latest',
-      secretAccessKey: getSecretAccessKey(this._builderConfig),
-      accessKeyId: getAccessKeyId(this._builderConfig),
+      secretAccessKey: getSecretAccessKey(),
+      accessKeyId: getAccessKeyId(),
     });
   }
 


### PR DESCRIPTION
Currently, when running `NG_DEPLOY_ENV_VARIABLES... yarn ng deploy` it throws an exception: `An unhandled exception occurred: Configuration 'production' is not set in the workspace.`, because it tries to get the `production` configuration which doesn't exist.