### PR TITLE
fix(subfolder): get subfolder config work again

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@
 5. Due to security risk we have made the decision to never add any options to the `angular.json`. You should set the environments variable during the `ng deploy` command.  Below a example on how you could do this.
 
 ```bash
-npx cross-env NG_DEPLOY_AWS_ACCESS_KEY_ID=1234 NG_DEPLOY_AWS_SECRET_ACCESS_KEY=321ACCESS NG_DEPLOY_AWS_BUCKET=mys3bucket NG_DEPLOY_AWS_REGION=eu-1-region ng deploy
+npx cross-env NG_DEPLOY_AWS_ACCESS_KEY_ID=1234 NG_DEPLOY_AWS_SECRET_ACCESS_KEY=321ACCESS NG_DEPLOY_AWS_BUCKET=mys3bucket NG_DEPLOY_AWS_REGION=eu-1-region NG_DEPLOY_AWS_SUB_FOLDER=path/on/bucker ng deploy
 ```
 6. Run `ng deploy` to deploy your application to Amazon S3.
 

--- a/libs/ngx-aws-deploy/src/lib/deploy/config.ts
+++ b/libs/ngx-aws-deploy/src/lib/deploy/config.ts
@@ -15,3 +15,7 @@ export const getBucket = (builderConfig: Schema): string => {
 export const getRegion = (builderConfig: Schema): string => {
   return process.env.NG_DEPLOY_AWS_REGION || (builderConfig.region as string);
 };
+
+export const getSubFolder = (builderConfig: Schema): string => {
+  return process.env.NG_DEPLOY_AWS_SUB_FOLDER || (builderConfig.subFolder as string);
+};

--- a/libs/ngx-aws-deploy/src/lib/deploy/index.ts
+++ b/libs/ngx-aws-deploy/src/lib/deploy/index.ts
@@ -36,20 +36,20 @@ export default createBuilder(
     };
 
     let targetString = `${context.target.project}:deploy`;
-    // Providing `region` and `bucket` through configuration is actually deprecated.
+    // Providing `region`, `bucket` and `subFolder` through configuration is actually deprecated.
     // By default `ng add` command doesn't generate any additional configuration inside
     // the builder configuration thus `context.target.configuration` defaults to an empty string.
     if (context.target.configuration) {
       targetString += `:${context.target.configuration}`;
     }
 
-    const { bucket, region } = await context.getTargetOptions(
+    const { bucket, region, subFolder } = await context.getTargetOptions(
       targetFromTargetString(targetString)
     );
 
-    const deployConfig = { bucket, region } as Pick<
+    const deployConfig = { bucket, region, subFolder } as Pick<
       Schema,
-      'bucket' | 'region'
+      'bucket' | 'region' | 'subFolder'
     >;
 
     let buildResult: BuilderOutput;

--- a/libs/ngx-aws-deploy/src/lib/deploy/uploader.ts
+++ b/libs/ngx-aws-deploy/src/lib/deploy/uploader.ts
@@ -9,7 +9,7 @@ import {
   getAccessKeyId,
   getBucket,
   getRegion,
-  getSecretAccessKey,
+  getSecretAccessKey, getSubFolder
 } from './config';
 
 export class Uploader {
@@ -17,6 +17,7 @@ export class Uploader {
   private _s3: AWS.S3;
   private _bucket: string;
   private _region: string;
+  private _subFolder: string;
   private _builderConfig: Schema;
 
   constructor(context: BuilderContext, builderConfig: Schema) {
@@ -24,6 +25,7 @@ export class Uploader {
     this._builderConfig = builderConfig;
     this._bucket = getBucket(this._builderConfig);
     this._region = getRegion(this._builderConfig);
+    this._subFolder = getSubFolder(this._builderConfig);
 
     AWS.config.update({ region: this._region });
     this._s3 = new AWS.S3({
@@ -81,8 +83,8 @@ export class Uploader {
 
     const params: PutObjectRequest = {
       Bucket: this._bucket,
-      Key: this._builderConfig.subFolder
-        ? `${this._builderConfig.subFolder}/${originFilePath}`
+      Key: this._subFolder
+        ? `${this._subFolder}/${originFilePath}`
         : originFilePath,
       Body: body,
       ContentType: mimeTypes.lookup(fileName) || undefined,


### PR DESCRIPTION
Currently, this is not possible to give a `subFolder` anymore since the move of upload configuration into environment variables. 
As the `subFolder` option is related to the S3 bucket, it sounded relevant to me to use the same system (prefixed environment variables) to pass it to the builder.