### PR TITLE
Support for AWS Temporal Credentials Authentication via AWS_SESSION_TOKEN env variable

### DIFF
--- a/libs/ngx-aws-deploy/src/lib/deploy/config.ts
+++ b/libs/ngx-aws-deploy/src/lib/deploy/config.ts
@@ -8,6 +8,10 @@ export const getSecretAccessKey = (): string => {
   return process.env.NG_DEPLOY_AWS_SECRET_ACCESS_KEY as string || process.env.AWS_SECRET_ACCESS_KEY as string;
 };
 
+export const getSessionToken = (): string => {
+  return process.env.NG_DEPLOY_AWS_SESSION_TOKEN as string || process.env.AWS_SESSION_TOKEN as string;
+};
+
 export const getBucket = (builderConfig: Schema): string => {
   return process.env.NG_DEPLOY_AWS_BUCKET || (builderConfig.bucket as string);
 };

--- a/libs/ngx-aws-deploy/src/lib/deploy/uploader.ts
+++ b/libs/ngx-aws-deploy/src/lib/deploy/uploader.ts
@@ -13,7 +13,6 @@ import {
   getSessionToken,
   getSubFolder,
 } from './config';
-import { CredentialsOptions } from 'aws-sdk/lib/credentials';
 
 export class Uploader {
   private _context: BuilderContext;

--- a/libs/ngx-aws-deploy/src/lib/deploy/uploader.ts
+++ b/libs/ngx-aws-deploy/src/lib/deploy/uploader.ts
@@ -9,8 +9,11 @@ import {
   getAccessKeyId,
   getBucket,
   getRegion,
-  getSecretAccessKey, getSubFolder
+  getSecretAccessKey,
+  getSessionToken,
+  getSubFolder,
 } from './config';
+import { CredentialsOptions } from 'aws-sdk/lib/credentials';
 
 export class Uploader {
   private _context: BuilderContext;
@@ -28,10 +31,14 @@ export class Uploader {
     this._subFolder = getSubFolder(this._builderConfig);
 
     AWS.config.update({ region: this._region });
+
     this._s3 = new AWS.S3({
       apiVersion: 'latest',
-      secretAccessKey: getSecretAccessKey(),
-      accessKeyId: getAccessKeyId(),
+      credentials: new AWS.Credentials({
+        secretAccessKey: getSecretAccessKey(),
+        accessKeyId: getAccessKeyId(),
+        sessionToken: getSessionToken()
+      })
     });
   }
 


### PR DESCRIPTION
### AWS Temporal Credentials Support

Support for uploading files with a Temporal AWS Credential obtained using the [AWS STS Service](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp.html).


### Usage sample:
```
export AWS_ACCESS_KEY_ID=%acceskey%
export AWS_SECRET_ACCESS_KEY=%secretKey%
export AWS_SESSION_TOKEN=%sessionToken%
```

or via Custom NG_DEPLOY variables: 
```
export NG_DEPLOY_AWS_ACCESS_KEY_ID=%acceskey%
export NG_DEPLOY_AWS_SECRET_ACCESS_KEY=%secretKey%
export NG_DEPLOY_AWS_SESSION_TOKEN=%sessionToken%
```


