### PR TITLE
update getCfDistributionId to return the cfDistributionId only from env variables

### DIFF
--- a/libs/ngx-aws-deploy/src/lib/deploy/cloudfront.ts
+++ b/libs/ngx-aws-deploy/src/lib/deploy/cloudfront.ts
@@ -25,7 +25,7 @@ export class CloudFront {
     this._builderConfig = builderConfig;
 
     this._region = getRegion(this._builderConfig);
-    this._cfDistributionId = getCfDistributionId(this._builderConfig);
+    this._cfDistributionId = getCfDistributionId();
     this._subFolder = getSubFolder(this._builderConfig);
 
     AWS.config.update({ region: this._region });

--- a/libs/ngx-aws-deploy/src/lib/deploy/config.ts
+++ b/libs/ngx-aws-deploy/src/lib/deploy/config.ts
@@ -20,6 +20,6 @@ export const getSubFolder = (builderConfig: Schema): string => {
   return process.env.NG_DEPLOY_AWS_SUB_FOLDER || (builderConfig.subFolder as string);
 };
 
-export const getCfDistributionId = (builderConfig: Schema): string => {
-  return process.env.NG_DEPLOY_AWS_CF_DISTRIBUTION_ID || (builderConfig.cfDistributionId as string);
+export const getCfDistributionId = (): string => {
+  return process.env.NG_DEPLOY_AWS_CF_DISTRIBUTION_ID;
 };


### PR DESCRIPTION
As I wrote [this fix](https://github.com/Jefiozie/ngx-aws-deploy/pull/408), I realized that we probably don't want the distributionId to be part of the targetConfig anyway.
So here is the alternative fix to https://github.com/Jefiozie/ngx-aws-deploy/pull/408 just so that we make it clear that cfDistributionId comes from env Variables only.