### PR TITLE
add missing cfDistributionId to the deployConfig

### DIFF
--- a/libs/ngx-aws-deploy/src/lib/deploy/index.ts
+++ b/libs/ngx-aws-deploy/src/lib/deploy/index.ts
@@ -44,14 +44,19 @@ export default createBuilder(
       targetString += `:${context.target.configuration}`;
     }
 
-    const { bucket, region, subFolder } = await context.getTargetOptions(
-      targetFromTargetString(targetString)
-    );
+    const {
+      bucket,
+      region,
+      subFolder,
+      cfDistributionId,
+    } = await context.getTargetOptions(targetFromTargetString(targetString));
 
-    const deployConfig = { bucket, region, subFolder } as Pick<
-      Schema,
-      'bucket' | 'region' | 'subFolder'
-    >;
+    const deployConfig = {
+      bucket,
+      region,
+      subFolder,
+      cfDistributionId,
+    } as Pick<Schema, 'bucket' | 'region' | 'subFolder' | 'cfDistributionId'>;
 
     let buildResult: BuilderOutput;
     if (builderConfig.noBuild) {


### PR DESCRIPTION
(New PR replacing https://github.com/Jefiozie/ngx-aws-deploy/pull/408 from a feature branch instead of main)

Fixes a bug where the distributionId could not be passed using the target config.