### PR TITLE
:sparkles:  #416 add AWS_PROFILE/NG_DEPLOY_AWS_PROFILE  environment and ext…

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,9 +69,10 @@ npx cross-env ... NG_DEPLOY_AWS_CF_DISTRIBUTION_ID=1234 ... ng deploy
 ## Security 🔑
 
 Keep in mind that **with the default config, everybody that has access to the angular.json will have your aws secret**.
-If you want more security, you can also use environment variable with `NG_DEPLOY_AWS_ACCESS_KEY_ID`, `NG_DEPLOY_AWS_SECRET_ACCESS_KEY`, `NG_DEPLOY_AWS_BUCKET` and `NG_DEPLOY_AWS_REGION`.
+If you want more security, you can also use environment variable with `NG_DEPLOY_AWS_ACCESS_KEY_ID`, `NG_DEPLOY_AWS_SECRET_ACCESS_KEY`, `NG_DEPLOY_AWS_BUCKET`, `NG_DEPLOY_AWS_REGION` and `NG_DEPLOY_AWS_PROFILE`.
 
 #### Minimal Required IAM Policy for AWS Credentials
+1. S3 permisions:
 ```
 {
     "Version": "2012-10-17",
@@ -98,7 +99,23 @@ If you want more security, you can also use environment variable with `NG_DEPLOY
     ]
 }
 ```
-
+2. cloudFront permisions:
+```
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "cloudfrontInvalidation",
+            "Effect": "Allow",
+            "Action": [
+                "cloudfront:GetDistribution",
+                "cloudfront:CreateInvalidation"
+            ],
+            "Resource": "arn:aws:cloudfront::${accountId}:distribution/${distributionId}"
+        }
+    ]
+}
+```
 ## Contributing
 
 Pull requests are welcome. For major changes, please open an issue first to discuss what you would like to change.

--- a/libs/ngx-aws-deploy/src/lib/deploy/aws-config/index.ts
+++ b/libs/ngx-aws-deploy/src/lib/deploy/aws-config/index.ts
@@ -1,0 +1,30 @@
+import * as AWS from 'aws-sdk';
+import {
+  getAccessKeyId,
+  getSecretAccessKey,
+  getSessionToken,
+  getAwsProfile,
+} from '../config';
+
+type Credentials = {
+  accessKeyId: string,
+  secretAccessKey: string,
+  sessionToken?: string
+}
+const secretAccessKey = getSecretAccessKey()
+const accessKeyId = getAccessKeyId()
+const sessionToken = getSessionToken()
+
+if(accessKeyId && secretAccessKey){
+  let credentials: Credentials = {
+    accessKeyId,
+    secretAccessKey
+  }
+  if(sessionToken){
+    credentials = {...credentials, sessionToken}
+  }
+  AWS.config.credentials = new AWS.Credentials(credentials)
+}else{
+  AWS.config.credentials = new AWS.SharedIniFileCredentials({profile: getAwsProfile()});
+}
+export default AWS

--- a/libs/ngx-aws-deploy/src/lib/deploy/cloudfront.ts
+++ b/libs/ngx-aws-deploy/src/lib/deploy/cloudfront.ts
@@ -1,10 +1,8 @@
 import { BuilderContext } from '@angular-devkit/architect';
-import * as AWS from 'aws-sdk';
+import AWS from './aws-config'
 import { CreateInvalidationRequest } from 'aws-sdk/clients/cloudfront';
 import { Schema } from './schema';
 import {
-  getAccessKeyId,
-  getSecretAccessKey,
   getRegion,
   getSubFolder,
   getCfDistributionId
@@ -31,8 +29,6 @@ export class CloudFront {
     AWS.config.update({ region: this._region });
     this._cloudFront = new AWS.CloudFront({
       apiVersion: 'latest',
-      secretAccessKey: getSecretAccessKey(),
-      accessKeyId: getAccessKeyId()
     });
   }
 

--- a/libs/ngx-aws-deploy/src/lib/deploy/config.ts
+++ b/libs/ngx-aws-deploy/src/lib/deploy/config.ts
@@ -50,3 +50,11 @@ export const gets3ForcePathStyle = (): boolean => {
 export const getAwsEndpoint = (): string => {
   return process.env.AWS_ENDPOINT;
 };
+
+export const getAwsProfile = (): string => {
+  return (
+    (process.env.AWS_PROFILE as string) || 
+    (process.env.NG_DEPLOY_AWS_PROFILE as string) ||
+    'default'
+  );
+};

--- a/libs/ngx-aws-deploy/src/lib/deploy/index.ts
+++ b/libs/ngx-aws-deploy/src/lib/deploy/index.ts
@@ -5,7 +5,7 @@ import {
   targetFromTargetString,
 } from '@angular-devkit/architect';
 import * as glob from 'glob';
-import { getAccessKeyId, getSecretAccessKey } from './config';
+import { getAccessKeyId, getSecretAccessKey, getAwsProfile } from './config';
 import { CloudFront } from './cloudfront';
 import { Schema } from './schema';
 import { Uploader } from './uploader';
@@ -90,7 +90,7 @@ export default createBuilder(
           'Target did not produce any files, or the path is incorrect.'
         );
       }
-      if (getAccessKeyId() || getSecretAccessKey()) {
+      if (getAccessKeyId() || getSecretAccessKey() || getAwsProfile()) {
         context.logger.info('Start uploading files...');
         const uploader = new Uploader(context, deployConfig);
         const success = await uploader.upload(files, filesPath);

--- a/libs/ngx-aws-deploy/src/lib/deploy/uploader.ts
+++ b/libs/ngx-aws-deploy/src/lib/deploy/uploader.ts
@@ -1,18 +1,15 @@
 import { BuilderContext } from '@angular-devkit/architect';
-import * as AWS from 'aws-sdk';
+import AWS from './aws-config'
 import { HeadBucketRequest, PutObjectRequest } from 'aws-sdk/clients/s3';
 import * as mimeTypes from 'mime-types';
 import * as fs from 'fs';
 import * as path from 'path';
 import { Schema } from './schema';
 import {
-  getAccessKeyId,
   getAwsEndpoint,
   getBucket,
   getRegion,
   gets3ForcePathStyle,
-  getSecretAccessKey,
-  getSessionToken,
   getSubFolder,
 } from './config';
 
@@ -37,11 +34,6 @@ export class Uploader {
       apiVersion: 'latest',
       s3ForcePathStyle: gets3ForcePathStyle() || false,
       endpoint: getAwsEndpoint(),
-      credentials: new AWS.Credentials({
-        secretAccessKey: getSecretAccessKey(),
-        accessKeyId: getAccessKeyId(),
-        sessionToken: getSessionToken(),
-      }),
     });
   }
 


### PR DESCRIPTION
add AWS_PROFILE/NG_DEPLOY_AWS_PROFILE environment and extends sessionToken to CloudFront invalidations

also was added support for the "default" profile when no  credentials or profile were provided; all credentials configurations were moved to  an  external file;  and the readme was updated with the policy needed to perform de cloudfront invalidations.