### PR TITLE
Add cfDistributionId to deployConfig

### DIFF
--- a/libs/ngx-aws-deploy/src/lib/deploy/index.ts
+++ b/libs/ngx-aws-deploy/src/lib/deploy/index.ts
@@ -44,13 +44,13 @@ export default createBuilder(
       targetString += `:${context.target.configuration}`;
     }
 
-    const { bucket, region, subFolder } = await context.getTargetOptions(
+    const { bucket, region, subFolder, cfDistributionId } = await context.getTargetOptions(
       targetFromTargetString(targetString)
     );
 
-    const deployConfig = { bucket, region, subFolder } as Pick<
+    const deployConfig = { bucket, region, subFolder, cfDistributionId } as Pick<
       Schema,
-      'bucket' | 'region' | 'subFolder'
+      'bucket' | 'region' | 'subFolder' | 'cfDistributionId'
     >;
 
     let buildResult: BuilderOutput;


### PR DESCRIPTION
# Description
I realize that reading `getCfDistributionId` from configuration is removed in later versions but I have an NX monorepo with multiple apps and each with their own CF distribution ids. So that makes it more difficult to define it using env vars. But in version `4.1.0` the `getCfDistributionId` value is not actually included in the `deployConfig` and thus cache invalidation doesn't work because it never receives the id.

This PR addresses that problem and it would be ideal if it could be released as version `4.1.1`.