### PR TITLE
- update glob to latest to fix ng-deploy in Angular 16

### DIFF
--- a/libs/ngx-aws-deploy/package.json
+++ b/libs/ngx-aws-deploy/package.json
@@ -29,7 +29,7 @@
     "@angular-devkit/core": ">=14.2.6",
     "@angular-devkit/schematics": ">=14.2.6",
     "aws-sdk": "^2.1238.0",
-    "glob": "^8.0.3",
+    "glob": "^10.3.3",
     "mime-types": "^2.1.35"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aws-deploy",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "aws-deploy",
-      "version": "5.0.0",
+      "version": "5.1.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
glob v8.0.3 is not supported by Angular 16.
it's giving an error when ng-deploy command run:
The "path" argument must be of type string. Received undefined.

so, I updated the Glob version to current latest 10.3.3.